### PR TITLE
explicitly export by all instead of import as

### DIFF
--- a/codegen/base/kubernetes-stubs/client/__init__.pyi
+++ b/codegen/base/kubernetes-stubs/client/__init__.pyi
@@ -1,7 +1,15 @@
-from kubernetes.client.api_client import ApiClient as ApiClient
-from kubernetes.client.configuration import Configuration as Configuration
-from kubernetes.client.exceptions import ApiException as ApiException
-from kubernetes.client.exceptions import ApiKeyError as ApiKeyError
-from kubernetes.client.exceptions import ApiTypeError as ApiTypeError
-from kubernetes.client.exceptions import ApiValueError as ApiValueError
-from kubernetes.client.exceptions import OpenApiException as OpenApiException
+from kubernetes.client.api_client import ApiClient
+from kubernetes.client.configuration import Configuration
+from kubernetes.client.exceptions import (ApiException, ApiKeyError,
+                                          ApiTypeError, ApiValueError,
+                                          OpenApiException)
+
+__all__ = [
+    "ApiClient",
+    "Configuration",
+    "ApiException",
+    "ApiKeyError",
+    "ApiTypeError",
+    "ApiValueError",
+    "OpenApiException",
+]

--- a/codegen/base/kubernetes-stubs/config/__init__.pyi
+++ b/codegen/base/kubernetes-stubs/config/__init__.pyi
@@ -1,13 +1,17 @@
-from kubernetes.config.config_exception import \
-    ConfigException as ConfigException
-from kubernetes.config.incluster_config import \
-    load_incluster_config as load_incluster_config
-from kubernetes.config.kube_config import \
-    KUBE_CONFIG_DEFAULT_LOCATION as KUBE_CONFIG_DEFAULT_LOCATION
-from kubernetes.config.kube_config import \
-    list_kube_config_contexts as list_kube_config_contexts
-from kubernetes.config.kube_config import load_kube_config as load_kube_config
-from kubernetes.config.kube_config import \
-    load_kube_config_from_dict as load_kube_config_from_dict
-from kubernetes.config.kube_config import \
-    new_client_from_config as new_client_from_config
+from kubernetes.config.config_exception import ConfigException
+from kubernetes.config.incluster_config import load_incluster_config
+from kubernetes.config.kube_config import (KUBE_CONFIG_DEFAULT_LOCATION,
+                                           list_kube_config_contexts,
+                                           load_kube_config,
+                                           load_kube_config_from_dict,
+                                           new_client_from_config)
+
+__all__ = [
+    "ConfigException",
+    "load_incluster_config",
+    "KUBE_CONFIG_DEFAULT_LOCATION",
+    "list_kube_config_contexts",
+    "load_kube_config",
+    "load_kube_config_from_dict",
+    "new_client_from_config",
+]


### PR DESCRIPTION
`from foo import x as x` looks ugly to me.

export those import names by `__all__` attribute.