### PR TITLE
fix: add stub for the kubernetes.config.load_config() wrapper function

### DIFF
--- a/codegen/base/kubernetes-stubs/config/__init__.pyi
+++ b/codegen/base/kubernetes-stubs/config/__init__.pyi
@@ -1,3 +1,6 @@
+from typing import Optional
+
+from kubernetes.client import Configuration
 from kubernetes.config.config_exception import ConfigException
 from kubernetes.config.incluster_config import load_incluster_config
 from kubernetes.config.kube_config import (KUBE_CONFIG_DEFAULT_LOCATION,
@@ -8,6 +11,7 @@ from kubernetes.config.kube_config import (KUBE_CONFIG_DEFAULT_LOCATION,
 
 __all__ = [
     "ConfigException",
+    "load_config",
     "load_incluster_config",
     "KUBE_CONFIG_DEFAULT_LOCATION",
     "list_kube_config_contexts",
@@ -15,3 +19,13 @@ __all__ = [
     "load_kube_config_from_dict",
     "new_client_from_config",
 ]
+
+
+def load_config(
+    config_file: Optional[str] = ...,
+    kube_config_path: Optional[str] = ...,
+    context: Optional[str] = ...,
+    client_configuration: Optional[Configuration] = ...,
+    persist_config: bool = ...,
+    try_refresh_token: bool = ...,
+) -> None: ...


### PR DESCRIPTION
For this function:

[Adding load_config wrapper method to have a more generic way of initializing the client config](https://github.com/kubernetes-client/python/commit/0c662bb33dfb49236ca4c68b81d426d8948da224)