### PR TITLE
upgrade poetry for pep 625

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
-poetry==1.1.7
+poetry~=1.3.0
 
 black~=21.6b0
 isort~=5.9.2


### PR DESCRIPTION
A warning from pypi:

> In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625.

upgrade poetry to comply with PEP 625.

ref: python-poetry/poetry#6621