### PR TITLE
Mark package as partial stub package

### DIFF
--- a/codegen/base/kubernetes-stubs/py.typed
+++ b/codegen/base/kubernetes-stubs/py.typed
@@ -1,0 +1,1 @@
+partial


### PR DESCRIPTION
Mark the package as a partial stub package as described [here](https://peps.python.org/pep-0561/#partial-stub-packages).
This allows to still see the definitions and docstrings from the `kubernetes` package for modules not defined in the stubs package (e.g. `utils` or `dynamic`).